### PR TITLE
Add ECA solver support and incremental option

### DIFF
--- a/scripts/single_sokoban.sh
+++ b/scripts/single_sokoban.sh
@@ -3,14 +3,14 @@
 case $(expr $1 + 1) in
     1 )
         echo "Solving sokoban example e2d_0_0..."
-        time code/solve sokoban e2d_0_0
+        time python3 code/solve.py sokoban e2d_0_0
         ;;
     2 )
         echo "Solving sokoban example e2d_1_0..."
-        time code/solve sokoban e2d_1_0
+        time python3 code/solve.py sokoban e2d_1_0
         ;;
     3 )
         echo "Solving sokoban example e2d_2_0..."
-        time code/solve sokoban e2d_2_0
+        time python3 code/solve.py sokoban e2d_2_0
         ;;
 esac


### PR DESCRIPTION
## Summary
- rename `Solve.py` to `solve.py` and make matplotlib optional
- add `solve_eca` function for ECA tasks with incremental mode
- improve CLI to handle both sokoban and eca tasks
- update single_sokoban script to call new entrypoint

## Testing
- `python -m py_compile code/solve.py`

------
https://chatgpt.com/codex/tasks/task_e_684807bc69a083288aa05455d899098a