### PR TITLE
Add formatted intermediate model output

### DIFF
--- a/code/ClingoParser.py
+++ b/code/ClingoParser.py
@@ -44,12 +44,15 @@ class ClingoParser:
         Parse raw Clingo output lines into Answer/Optimization objects.
         """
         outputs: List[ClingoOutputType] = []
-        i = 0
-        while i < len(lines):
-
-            outputs.append(Answer(answer=lines[i ]))
-                
-            i += 1
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith(self.OPT_PREFIX):
+                opt = line[len(self.OPT_PREFIX):].strip()
+                outputs.append(Optimization(optimization=opt))
+            else:
+                outputs.append(Answer(answer=line))
         return outputs
 
     def last_outputs(self, outputs: List[Answer]) -> List[ClingoOutputType]:

--- a/code/solve.py
+++ b/code/solve.py
@@ -827,6 +827,15 @@ def do_solve(
             outf.write(model_to_string(m) + "\n")
     print(f"Results written to {result_path}")
 
+    # Additionally write human-readable models
+    formatted_path = os.path.join("temp", f"{tmp_dir}_{name}_results_ex.txt")
+    with open(formatted_path, "w") as outf:
+        for idx, m in enumerate(model_buf, start=1):
+            outf.write(f"--- Model {idx} ---\n")
+            outf.write("\n".join(pretty(m, template, parser, presenter)))
+            outf.write("\n\n")
+    print(f"Formatted results written to {formatted_path}")
+
     # Parse final outputs
     parsed_outputs = parser.parse_lines([model_to_string(current_model)])[0]
 


### PR DESCRIPTION
## Summary
- handle optimization lines in `ClingoParser`
- output formatted intermediate models in `solve.do_solve`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684849a440388328bf49a3918311c396