### PR TITLE
Add Pacman 2D dataset

### DIFF
--- a/code/PacmanData2D.py
+++ b/code/PacmanData2D.py
@@ -1,0 +1,142 @@
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import List, Tuple
+
+
+class PacmanAction(Enum):
+    """Possible actions for Pacman."""
+    STOP = auto()
+    LEFT = auto()
+    RIGHT = auto()
+    UP = auto()
+    DOWN = auto()
+
+    def __str__(self) -> str:
+        return {
+            PacmanAction.STOP: "stop",
+            PacmanAction.LEFT: "west",
+            PacmanAction.RIGHT: "east",
+            PacmanAction.UP: "north",
+            PacmanAction.DOWN: "south",
+        }[self]
+
+
+@dataclass(frozen=True, order=True)
+class Example:
+    """Simple Pacman example description."""
+    initial_state: List[str]
+    actions: List[PacmanAction]
+    num_input: int
+    num_held_out: int
+
+
+# ---------------------------------------------------------------------------
+# Example task descriptions
+# ---------------------------------------------------------------------------
+
+state_2d_1: List[str] = [
+    "#######",
+    "#.....#",
+    "#.p.o.#",
+    "#..g..#",
+    "#######",
+]
+example_2d_1 = Example(
+    initial_state=state_2d_1,
+    actions=[
+        PacmanAction.DOWN, PacmanAction.RIGHT,
+        PacmanAction.UP, PacmanAction.LEFT,
+        PacmanAction.DOWN, PacmanAction.RIGHT,
+        PacmanAction.UP, PacmanAction.LEFT,
+        PacmanAction.DOWN, PacmanAction.RIGHT,
+        PacmanAction.UP, PacmanAction.LEFT,
+    ],
+    num_input=0,
+    num_held_out=0,
+)
+
+state_2d_2: List[str] = [
+    "#########",
+    "#p..o...#",
+    "###.###.#",
+    "#..g....#",
+    "#########",
+]
+example_2d_2 = Example(
+    initial_state=state_2d_2,
+    actions=[
+        PacmanAction.RIGHT, PacmanAction.RIGHT,
+        PacmanAction.DOWN, PacmanAction.LEFT,
+        PacmanAction.UP, PacmanAction.UP,
+        PacmanAction.RIGHT, PacmanAction.DOWN,
+        PacmanAction.LEFT, PacmanAction.LEFT,
+        PacmanAction.UP, PacmanAction.RIGHT,
+    ],
+    num_input=0,
+    num_held_out=0,
+)
+
+state_2d_3: List[str] = [
+    "########",
+    "#g..p..#",
+    "#..o#..#",
+    "#......#",
+    "########",
+]
+example_2d_3 = Example(
+    initial_state=state_2d_3,
+    actions=[
+        PacmanAction.LEFT, PacmanAction.LEFT,
+        PacmanAction.RIGHT, PacmanAction.UP,
+        PacmanAction.DOWN, PacmanAction.RIGHT,
+        PacmanAction.LEFT, PacmanAction.DOWN,
+        PacmanAction.UP, PacmanAction.RIGHT,
+        PacmanAction.STOP, PacmanAction.LEFT,
+    ],
+    num_input=0,
+    num_held_out=0,
+)
+
+
+# ---------------------------------------------------------------------------
+# Variant generation utilities
+# ---------------------------------------------------------------------------
+
+
+def make_example(ex: Example, n: int) -> Example:
+    """Return a copy of ``ex`` with the last ``n`` actions held out."""
+    total = len(ex.actions)
+    kept = ex.actions[: total - n] if n <= total else []
+    return Example(
+        initial_state=ex.initial_state,
+        actions=kept,
+        num_input=total + 1 - n,
+        num_held_out=n,
+    )
+
+
+def make_n_examples(n: int, ex: Example) -> List[Tuple[str, Example]]:
+    """Generate seven variants of an example named ``e2d_{n}_{i}``."""
+    variants: List[Tuple[str, Example]] = []
+    for i in range(7):
+        name = f"e2d_{n}_{i}"
+        variants.append((name, make_example(ex, i)))
+    return variants
+
+
+# Base examples
+examples_2d: List[Example] = [example_2d_1, example_2d_2, example_2d_3]
+
+# Flatten all named example variants
+pacman_examples: List[Tuple[str, Example]] = []
+for idx, ex in enumerate(examples_2d):
+    pacman_examples.extend(make_n_examples(idx, ex))
+
+__all__ = [
+    "examples_2d",
+    "make_example",
+    "make_n_examples",
+    "pacman_examples",
+    "PacmanAction",
+    "Example",
+]


### PR DESCRIPTION
## Summary
- introduce `PacmanData2D` with simple Pacman tasks
- provide action enum `PacmanAction` and utilities to create held‑out variants
- update states to look more like mazes

## Testing
- `python -m py_compile code/PacmanData2D.py`


------
https://chatgpt.com/codex/tasks/task_e_6849574653b48328957f4a250063d458