### PR TITLE
Implement Pacman ghost and power rules

### DIFF
--- a/code/PacmanTypes.py
+++ b/code/PacmanTypes.py
@@ -37,6 +37,9 @@ class State:
     pacman: Pos
     pellets: List[Pos] = field(default_factory=list)
     ghosts: List[Pos] = field(default_factory=list)
+    ghost_dirs: List[PacmanAction] = field(default_factory=list)
+    powered: bool = False
+    alive: bool = True
 
 
 @dataclass(order=True, frozen=True)


### PR DESCRIPTION
## Summary
- extend `State` dataclass with ghost directions, power and life flags
- update parsing helpers to create the new state
- rewrite `perform_action` to handle ghost movement, pellet power, and collisions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849615df21083288ed72ac1242a352d