### PR TITLE
Add character hierarchy for pacman

### DIFF
--- a/code/SolveTemplates.py
+++ b/code/SolveTemplates.py
@@ -218,8 +218,8 @@ def frame_pacman(max_x: int, max_y: int, num_pellets: int, num_ghosts: int) -> F
     """Return a basic Pacman frame."""
 
     return Frame(
-        types=[T("cell"), T("pacman"), T("pellet"), T("ghost")],
-        type_hierarchy=[],
+        types=[T("cell"), T("character"), T("pacman"), T("pellet"), T("ghost")],
+        type_hierarchy=[(T("character"), [T("pacman"), T("ghost")])],
         objects=[(O("pacman"), T("pacman"))]
                 + [(O(f"pellet_{i}"), T("pellet")) for i in range(1, num_pellets + 1)]
                 + [(O(f"ghost_{i}"), T("ghost")) for i in range(1, num_ghosts + 1)]
@@ -239,6 +239,8 @@ def frame_pacman(max_x: int, max_y: int, num_pellets: int, num_ghosts: int) -> F
             (C("in_pacman"), [T("pacman"), T("cell")]),
             (C("in_ghost"), [T("ghost"), T("cell")]),
             (C("pellet_at"), [T("pellet"), T("cell")]),
+            (C("alive"), [T("character")]),
+            (C("dead"), [T("character")]),
             (C("noop"), [T("pacman")]),
             (C("left"), [T("pacman")]),
             (C("right"), [T("pacman")]),
@@ -249,6 +251,8 @@ def frame_pacman(max_x: int, max_y: int, num_pellets: int, num_ghosts: int) -> F
             C("in_pacman"),
             C("in_ghost"),
             C("pellet_at"),
+            C("alive"),
+            C("dead"),
             C("noop"),
             C("left"),
             C("right"),


### PR DESCRIPTION
## Summary
- define `character` type as a parent of `pacman` and `ghost`
- allow the frame to track whether characters are `alive` or `dead`

## Testing
- `python3 -m py_compile code/SolveTemplates.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849672d8ce88328acf4a90dcd0dbcbd