### PR TITLE
Fix Pacman example generator

### DIFF
--- a/code/Pacman.py
+++ b/code/Pacman.py
@@ -30,7 +30,10 @@ def get_bounds(lines: List[str]) -> Pos:
 
 
 def strings_to_state(lines: List[str]) -> State:
+    """Parse a grid of characters into a ``State`` object."""
+
     b = get_bounds(lines)
+
     walls: List[Pos] = []
     pellets: List[Pos] = []
     ghosts: List[Pos] = []
@@ -40,34 +43,17 @@ def strings_to_state(lines: List[str]) -> State:
 
     for y, row in enumerate(lines, start=1):
         for x, ch in enumerate(row, start=1):
-            if ch == '#':
-                state = State(
-                    cells=Cells(bounds=state.cells.bounds,
-                                walls=state.cells.walls + [(x, y)]),
-                    pacman=state.pacman,
-                    pellets=state.pellets,
-                    ghosts=state.ghosts,
-                    ghost_dirs=state.ghost_dirs,
-                    powered=state.powered,
-                    alive=state.alive
-                )
-            elif ch == 'o':
+            if ch in {"#", "w"}:
+                walls.append((x, y))
+            elif ch == "o":
                 pellets.append((x, y))
-            elif ch == 'g':
+            elif ch == "g":
                 ghosts.append((x, y))
+                # Default orientation is left; ``state_to_strings`` ignores it
                 ghost_dirs.append(PacmanAction.LEFT)
                 ghost_alive.append(True)
-            elif ch == 'p':
-                state = State(
-                    cells=state.cells,
-                    pacman=(x, y),
-                    pellets=state.pellets,
-                    ghosts=state.ghosts,
-                    ghost_dirs=state.ghost_dirs,
-                    powered=state.powered,
-                    alive=state.alive
-                )
-    return state
+            elif ch == "p":
+                pacman = (x, y)
 
     cells = Cells(bounds=b, walls=walls)
     return State(

--- a/code/PacmanTypes.py
+++ b/code/PacmanTypes.py
@@ -89,16 +89,9 @@ def state_to_strings(state: State) -> List[str]:
     for pos in state.pellets:
         grid = update_strings(grid, pos, 'o')
 
-    # draw ghosts with orientation
-    dir_to_char = {
-        PacmanAction.LEFT: '<',
-        PacmanAction.RIGHT: '>',
-        PacmanAction.UP: '^',
-        PacmanAction.DOWN: 'v',
-    }
-    for pos, d in zip(state.ghosts, state.ghost_dirs):
-        char = dir_to_char.get(d, 'g')
-        grid = update_strings(grid, pos, char)
+    # draw ghosts (orientation is ignored in the string representation)
+    for pos in state.ghosts:
+        grid = update_strings(grid, pos, 'g')
 
     # draw pacman last
     grid = update_strings(grid, state.pacman, 'p')


### PR DESCRIPTION
## Summary
- fix `strings_to_state` in `Pacman.py`
- ignore ghost orientation in `state_to_strings`

## Testing
- `python code/Pacman.py all`
- `python code/test.py` *(fails: parsing failed)*

------
https://chatgpt.com/codex/tasks/task_e_68496d2c37108328ae8d5971e88e46f1