### PR TITLE
Handle _known_externals cleanup

### DIFF
--- a/code/solve.py
+++ b/code/solve.py
@@ -634,11 +634,11 @@ def _interesting_atoms(model: Sequence[Symbol]) -> list[Symbol]:
 
 
 def _wipe_all_hints(ctrl: clingo.Control) -> None:
-    """Set every known ``hint/1`` external to *false*."""
+    """Set every known ``hint/1`` external to *false* and remove it."""
     for ext, is_on in list(_known_externals.items()):
         if is_on:
             ctrl.release_external(ext)
-            _known_externals[ext] = False
+            _known_externals.pop(ext, None)
 
 def _activate_hints(ctrl: clingo.Control, atoms: Iterable[Symbol], step: int) -> None:
     """Attach *heuristic* guidance for *atoms* (declare once, enable this step)."""


### PR DESCRIPTION
## Summary
- free soft hint externals and drop them from `_known_externals`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 code/test.py` *(fails: `data/sokoban/predict_e1d_0_0.lp` missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae44279888328b8e93c2ccdb04ca8