### PR TITLE
Add explicit GC cleanup after solving

### DIFF
--- a/code/solve.py
+++ b/code/solve.py
@@ -11,6 +11,7 @@ from clingo.symbol import Number, Function, Symbol
 from typing import Iterable, Sequence
 from Interpretation import Type as T, Object, Var, Concept, Template
 from ClingoParser import ClingoOutput, ClingoResult, ClingoParser, ClingoPresenter, write_latex
+import gc
 
 from pathlib import Path
 
@@ -749,6 +750,8 @@ def _minimal_core(
         if not result.satisfiable:
             shrunk.remove(lit)
             print(f"Removed {lit} from core, remaining: {len(shrunk)}")
+        del result
+        gc.collect()
 
     return shrunk
 
@@ -857,6 +860,8 @@ def _run_incremental(
         )
         print(core)
         hard = result.satisfiable
+        del result
+        gc.collect()
 
         if not hard and core:
             
@@ -875,6 +880,8 @@ def _run_incremental(
                 on_core=lambda c: core.extend(c)
             )
             hard = result.satisfiable
+            del result
+            gc.collect()
 
         # Fallback to soft
         if not hard:

--- a/code/test.py
+++ b/code/test.py
@@ -15,6 +15,7 @@ import logging
 import time
 from pathlib import Path
 from typing import Callable, Iterable, List, Sequence, Tuple
+import gc
 
 import clingo
 from clingo.symbol import Function, Number
@@ -140,6 +141,8 @@ def main() -> None:
 
     models: list[list[clingo.Symbol]] = []
     ctl.solve(on_model=make_on_model(models), on_statistics=make_on_stats(2))
+    ctl.cleanup()
+    gc.collect()
 
     if not models:
         log.error("No model for steps 1–2 – aborting.")
@@ -166,6 +169,8 @@ def main() -> None:
             on_statistics=make_on_stats(step),
             assumptions=assumptions,
         )
+        ctl.cleanup()
+        gc.collect()
 
         if not models:
             log.warning("UNSAT at step %d – stopping.", step)


### PR DESCRIPTION
## Summary
- import `gc` in solver and test scripts
- ensure `SolveResult` objects are freed after checking `result.satisfiable`
- release clingo resources after each solve in test

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852f05297548328a739a447b61874bd